### PR TITLE
Feature - issue 5 - inspect container

### DIFF
--- a/DashboardServer/CommandServer/CommandServer.cs
+++ b/DashboardServer/CommandServer/CommandServer.cs
@@ -94,6 +94,10 @@ namespace DashboardServer.CommandServer {
                 case ContainerActionType.REFETCH_STATS:
                     await ContainerAction.RefetchStatsData(p);
                     break;
+                case ContainerActionType.INSPECT:
+                    var inspectParam = JsonConvert.DeserializeObject<InspectContainerParameters>(jsonParameterString);
+                    await ContainerAction.InspectContainer(inspectParam, p);
+                    break;
                 default:
                     await KafkaHelpers.SendMessageAsync(KafkaHelpers.ResponseTopic, new ContainerResponse { ResponseStatusCode = 404, Message = ResponseMessageContracts.METHOD_CALL_NOT_VIABLE }, p);
                     break;

--- a/DashboardServer/CommandServer/ContainerRequests/ContainerRequest.cs
+++ b/DashboardServer/CommandServer/ContainerRequests/ContainerRequest.cs
@@ -12,7 +12,8 @@ namespace DashboardServer.CommandServer.ContainerRequests {
         RENAME,
         UPDATE_CONFIGURATION,
         REFETCH_OVERVIEW,
-        REFETCH_STATS
+        REFETCH_STATS,
+        INSPECT
     }
     public struct ContainerRequest {
         [JsonProperty(Required = Required.Always)]

--- a/DashboardServer/CommandServer/ContainerRequests/InspectContainerParameters.cs
+++ b/DashboardServer/CommandServer/ContainerRequests/InspectContainerParameters.cs
@@ -1,0 +1,12 @@
+﻿using Newtonsoft.Json;
+
+namespace DashboardServer.CommandServer.ContainerRequests
+{
+    public class InspectContainerParameters
+    {
+        [JsonProperty(Required = Required.Always)]
+        public const ContainerActionType Action = ContainerActionType.INSPECT;
+        [JsonProperty(Required = Required.Always)]
+        public string ContainerId { get; set; }
+    }
+}

--- a/DashboardServer/CommandServer/ContainerResponses/InspectContainerResponse.cs
+++ b/DashboardServer/CommandServer/ContainerResponses/InspectContainerResponse.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+
+namespace DashboardServer.CommandServer.ContainerResponses
+{
+    public class InspectContainerResponse
+    {
+        [JsonProperty(Required = Required.Always)]
+        public string ServerName { get; set; }
+        [JsonProperty(Required = Required.Always)]
+        public string ContainerId { get; set; }
+        [JsonProperty(Required = Required.Always)]
+        public string RawData { get; set; }
+    }
+}

--- a/DashboardServer/CommandServer/Contracts/ResponseMessageContracts.cs
+++ b/DashboardServer/CommandServer/Contracts/ResponseMessageContracts.cs
@@ -10,5 +10,6 @@ namespace DashboardServer.CommandServer.Contracts {
         public const string METHOD_CALL_NOT_VIABLE = "Method call not viable. Contact maintainer for possilble implementation";
         public const string OVERVIEW_DATA_REFETCHED = "Overview data manually refetched";
         public const string STATS_DATA_REFETCHED = "Stats data manually refetched";
+        public const string CONTAINER_INSPECTED = "Container successfully inspected";
     }
 }

--- a/DashboardServer/DashboardServer.csproj
+++ b/DashboardServer/DashboardServer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/DashboardServer/Updaters/DockerUpdater.cs
+++ b/DashboardServer/Updaters/DockerUpdater.cs
@@ -13,6 +13,7 @@ namespace DashboardServer.Updaters {
         private static readonly DockerClient _client = new DockerClientConfiguration(new Uri("unix:///var/run/docker.sock")).CreateClient();
         public const string OverviewTopic = "f0e1e946-50d0-4a2b-b1a5-f21b92e09ac1-general_info";
         public const string StatsTopic = "33a325ce-b0c0-43a7-a846-4f46acdb367e-stats_info";
+        public const string InspectTopic = "8f69fb50-ad11-4a9d-b4ab-21fba03053f2-inspect_info";
         private static int _checkInterval = Convert.ToInt32(Environment.GetEnvironmentVariable("DASHBOARDS_CHECK_INTERVAL_SECONDS")) == 0 ? 15 : Convert.ToInt32(Environment.GetEnvironmentVariable("DASHBOARDS_CHECK_INTERVAL_SECONDS"));
         private static int _sendInterval = 15;
         private static string[] _processesToStart = (Environment.GetEnvironmentVariable("DASHBOARDS_PROCESSES_TO_START") ?? "overviewdata,statsdata,commandserver").Split(",");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 
 services:
   server:
-    image: dst/dashboard-server
-    container_name: dashboard-server123
+    image: omvk97/dashboard-server
+    container_name: dashboard-server
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: "3"
 
 services:
   server:
-    image: omvk97/dashboard-server
-    container_name: dashboard-server
+    image: dst/dashboard-server
+    container_name: dashboard-server123
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:


### PR DESCRIPTION
Dashboard server feature to inspect a container based on a command in the command request topic. It emits an event on the new Inspect topic. The inspect info is indent formatted as a JSON string (meaning it is meant for viewing, it has to be deseralized again to be an implemented object).
Related to issue 7 on Dashboard-Interface-Docker repository: https://github.com/jakobhviid/Dashboard-Interface-Docker/issues/7