### PR TITLE
DashboardServer handles signals

### DIFF
--- a/DashboardServer/Program.cs
+++ b/DashboardServer/Program.cs
@@ -9,12 +9,23 @@ namespace DashboardServer {
         static async Task Main(string[] args) {
             
             CancellationTokenSource cts = new CancellationTokenSource();
+
+            //Handle sigterm signals
+            AppDomain.CurrentDomain.ProcessExit += (_, e) => {
+                cts.Cancel();
+                Environment.ExitCode = 0;
+                return;
+            };
+
+            //Handle sigint signals
             Console.CancelKeyPress += (_, e) => {
                 // when CTRL C is pressed, terminate the process. Otherwise keep it going
                 e.Cancel = true;
                 cts.Cancel();
-                System.Environment.Exit(0);
+                Environment.ExitCode = 0;
+                return;
             };
+
             var processesToStart = (Environment.GetEnvironmentVariable("DASHBOARDS_PROCESSES_TO_START") ?? "overviewdata,statsdata,commandserver").Split(",");
 
             IList<Task> tasks = new List<Task>();
@@ -32,5 +43,6 @@ namespace DashboardServer {
             Console.WriteLine("Started Docker Updaters");
             await Task.WhenAll(tasks); // Don't exit program
         }
+
     }
 }

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -8,4 +8,7 @@ replace-librdkafka.sh
 
 check-environment.sh
 
-dotnet "$DOTNET_PROGRAM_HOME"/DashboardServer.dll
+#Should ideally never be triggered, DashboardServer.dll handles signals and is set as PID 1.
+trap 'exit 0' SIGTERM
+
+exec dotnet "$DOTNET_PROGRAM_HOME"/DashboardServer.dll


### PR DESCRIPTION
Notes:
I'm not entirely confident that changing dashboardServer.dll to being
Pid 1 with exec is desireable but it seems to be the only way to let
the dashboardServer handle the signals properly.

Changes:
- DashboardServer.dll is changed to be pid 1 and it now handles signals.
- Environment.Exit() is incapeable of properly exitting when called
	from the signal handlers, so changed existing SIGINT handler to use
	return instead of Environment.Exit(). I believe this is also a bit
	more 'proper', I dont think Exit() should be used for a ordinary
	shutdown.
- Added a trap to docker-entrypoint.sh as a backup.